### PR TITLE
feat: Update server compatibility

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -26,7 +26,8 @@ jobs:
         node-version: lts/*
         check-latest: true
     - run: |
-        npm install -g appium
+        appium_ver=$(node -p "require('./package.json').peerDependencies?.appium")
+        npm install -g "appium@$appium_ver"
         npm install
       name: Install dev dependencies
     - run: |

--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ This is Appium driver for automating Safari on [macOS](https://developer.apple.c
 The driver only supports Safari automation using [W3C WebDriver protocol](https://www.w3.org/TR/webdriver/).
 Under the hood this driver is a wrapper/proxy over Apple's `safaridriver` binary. Check the output of `man safaridriver` command to get more details on the supported features and possible pitfalls.
 
-> **Note**
->
-> Since version 3.0.0 Safari driver has dropped the support of Appium 1, and is only compatible to Appium 2. Use the `appium driver install safari`
-> command to add it to your Appium 2 dist.
+> [!IMPORTANT]
+> Since major version *4.0.0* this driver is only compatible to Appium 3. Use the `appium driver install safari`
+> command to add it to your dist.
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The driver only supports Safari automation using [W3C WebDriver protocol](https:
 Under the hood this driver is a wrapper/proxy over Apple's `safaridriver` binary. Check the output of `man safaridriver` command to get more details on the supported features and possible pitfalls.
 
 > [!IMPORTANT]
-> Since major version *4.0.0* this driver is only compatible to Appium 3. Use the `appium driver install safari`
-> command to add it to your dist.
+> Since major version *4.0.0*, this driver is only compatible with Appium 3. Use the `appium driver install safari`
+> command to add it to your distribution.
 
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "url": "https://github.com/appium/appium-safari-driver/issues"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   },
   "prettier": {
     "bracketSpacing": false,
@@ -42,10 +42,10 @@
     "asyncbox": "^3.0.0",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.4",
-    "node-simctl": "^7.0.1",
+    "node-simctl": "^8.0.0",
     "portscanner": "2.2.0",
     "source-map-support": "^0.x",
-    "teen_process": "^2.0.0"
+    "teen_process": "^3.0.0"
   },
   "scripts": {
     "build": "tsc -b",
@@ -59,19 +59,18 @@
     "e2e-test": "mocha --exit --timeout 5m \"./test/functional/**/*-specs.js\""
   },
   "peerDependencies": {
-    "appium": "^2.0.0"
+    "appium": "^3.0.0-rc.2"
   },
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.0.0",
-    "@appium/tsconfig": "^0.x",
-    "@appium/types": "^0.x",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
+    "@appium/tsconfig": "^1.0.0-rc.1",
+    "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/bluebird": "^3.5.38",
     "@types/lodash": "^4.14.196",
     "@types/mocha": "^10.0.1",
     "@types/node": "^24.0.0",
-    "@types/teen_process": "^2.0.0",
     "chai": "^5.1.1",
     "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^9.0.0",


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10
BREAKING CHANGE: Required Appium server version has been bumped to >=3.0.0-rc.2