### PR TITLE
chore: drop rimraf deps from dev deps as no references

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^9.0.0",
     "mocha": "^11.1.0",
-    "rimraf": "^5.0.0",
     "semantic-release": "^24.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.4.2",


### PR DESCRIPTION
```
kazu $ git grep 'rimraf'
CHANGELOG.md:* **deps-dev:** bump rimraf from 4.4.1 to 5.0.0 ([#54](https://github.com/appium/appium-safari-driver/issues/54)) ([c5aed74](https://github.com/appium/appium-safari-driver/commit/c5aed746b594763e26f543647ef452f58fe0e223))
CHANGELOG.md:* **deps-dev:** bump rimraf from 3.0.2 to 4.0.4 ([#51](https://github.com/appium/appium-safari-driver/issues/51)) ([f962fdb](https://github.com/appium/appium-safari-driver/commit/f962fdbfbf48ae43c62811703ee6bc973763400a))
lib/commands/record-screen.js:      fs.rimrafSync(videoFile);
lib/commands/record-screen.js:      await fs.rimraf(videoPath);
package.json:    "rimraf": "^5.0.0",
```

instead of https://github.com/appium/appium-safari-driver/pull/125