### PR TITLE
feat: Migrate package to ESM

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -30,6 +30,23 @@ jobs:
         npm install -g "appium@$appium_ver"
         npm install
       name: Install dev dependencies
+    - run: sudo safaridriver --enable
+      name: Enable safaridriver
+    - run: |
+        RUNTIME_INFO=$(xcrun simctl list runtimes available -j | jq -c '[.runtimes[] | select(.isAvailable and (.identifier | startswith("com.apple.CoreSimulator.SimRuntime.iOS-")))] | last')
+        PLATFORM_VERSION=$(echo "$RUNTIME_INFO" | jq -r '.version')
+        RUNTIME_NAME=$(echo "$RUNTIME_INFO" | jq -r '.name')
+        DEVICE_NAME=$(xcrun simctl list devices available -j | jq -r --arg name "$RUNTIME_NAME" '.devices[$name][]? | select(.isAvailable and (.name | test("^iPhone "))) | .name' | head -1)
+        if [[ -z "$PLATFORM_VERSION" || -z "$DEVICE_NAME" ]]; then
+          echo "Unable to find an available iPhone simulator"
+          xcrun simctl list runtimes available
+          xcrun simctl list devices available
+          exit 1
+        fi
+        echo "PLATFORM_VERSION=$PLATFORM_VERSION" >> "$GITHUB_ENV"
+        echo "DEVICE_NAME=$DEVICE_NAME" >> "$GITHUB_ENV"
+        echo "Using $DEVICE_NAME ($RUNTIME_NAME)"
+      name: Configure mobile Safari e2e simulator
     - run: |
         cwd=$(pwd)
         pushd "$cwd"

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -17,8 +17,10 @@ jobs:
       APPIUM_TEST_SERVER_PORT: 4567
       APPIUM_TEST_SERVER_HOST: 127.0.0.1
       APPIUM_STARTUP_TIMEOUT_SEC: 30
+      PLATFORM_VERSION: '26.5'
+      DEVICE_NAME: iPhone 17
       _FORCE_LOGS: 1
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
@@ -32,21 +34,6 @@ jobs:
       name: Install dev dependencies
     - run: sudo safaridriver --enable
       name: Enable safaridriver
-    - run: |
-        RUNTIME_INFO=$(xcrun simctl list runtimes available -j | jq -c '[.runtimes[] | select(.isAvailable and (.identifier | startswith("com.apple.CoreSimulator.SimRuntime.iOS-")))] | last')
-        PLATFORM_VERSION=$(echo "$RUNTIME_INFO" | jq -r '.version')
-        RUNTIME_NAME=$(echo "$RUNTIME_INFO" | jq -r '.name')
-        DEVICE_NAME=$(xcrun simctl list devices available -j | jq -r --arg name "$RUNTIME_NAME" '.devices[$name][]? | select(.isAvailable and (.name | test("^iPhone "))) | .name' | head -1)
-        if [[ -z "$PLATFORM_VERSION" || -z "$DEVICE_NAME" ]]; then
-          echo "Unable to find an available iPhone simulator"
-          xcrun simctl list runtimes available
-          xcrun simctl list devices available
-          exit 1
-        fi
-        echo "PLATFORM_VERSION=$PLATFORM_VERSION" >> "$GITHUB_ENV"
-        echo "DEVICE_NAME=$DEVICE_NAME" >> "$GITHUB_ENV"
-        echo "Using $DEVICE_NAME ($RUNTIME_NAME)"
-      name: Configure mobile Safari e2e simulator
     - run: |
         cwd=$(pwd)
         pushd "$cwd"

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -12,13 +12,26 @@ concurrency:
 
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - target: desktop
+          npm_script: e2e-test:desktop
+          artifact: appium-desktop.log
+        - target: simulator
+          npm_script: e2e-test:simulator
+          artifact: appium-simulator.log
+          platform_version: '26.5'
+          device_name: iPhone 17
+    name: ${{ matrix.target }}
     env:
       CI: true
       APPIUM_TEST_SERVER_PORT: 4567
       APPIUM_TEST_SERVER_HOST: 127.0.0.1
       APPIUM_STARTUP_TIMEOUT_SEC: 30
-      PLATFORM_VERSION: '26.5'
-      DEVICE_NAME: iPhone 17
+      PLATFORM_VERSION: ${{ matrix.platform_version }}
+      DEVICE_NAME: ${{ matrix.device_name }}
       _FORCE_LOGS: 1
     runs-on: macos-26
     steps:
@@ -34,6 +47,21 @@ jobs:
       name: Install dev dependencies
     - run: sudo safaridriver --enable
       name: Enable safaridriver
+    - name: Prepare iOS simulator
+      if: matrix.target == 'simulator'
+      id: prepareSimulator
+      uses: futureware-tech/simulator-action@v5
+      with:
+        model: "${{ matrix.device_name }}"
+        os_version: "${{ matrix.platform_version }}"
+        shutdown_after_job: false
+        wait_for_boot: true
+    - name: Finalize iOS simulator boot
+      if: matrix.target == 'simulator'
+      run: xcrun --sdk iphonesimulator --show-sdk-version
+    - name: Set simulator UDID
+      if: matrix.target == 'simulator'
+      run: echo "DEVICE_UDID=${{ steps.prepareSimulator.outputs.udid }}" >> "$GITHUB_ENV"
     - run: |
         cwd=$(pwd)
         pushd "$cwd"
@@ -57,11 +85,11 @@ jobs:
           fi
         done
       name: Wait for Appium server startup
-    - run: npm run e2e-test
-      name: Run functional tests
+    - run: npm run ${{ matrix.npm_script }}
+      name: Run ${{ matrix.target }} functional tests
     - name: Save server output
       if: ${{ always() }}
       uses: actions/upload-artifact@master
       with:
-        name: appium.log
+        name: ${{ matrix.artifact }}
         path: appium.log

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,4 +1,0 @@
-module.exports = {
-  require: ['ts-node/register'],
-  forbidOnly: Boolean(process.env.CI)
-};

--- a/lib/commands/cookies.ts
+++ b/lib/commands/cookies.ts
@@ -1,4 +1,4 @@
-import type {SafariDriver} from '../driver';
+import type {SafariDriver} from '../driver.js';
 
 /**
  * Delete all cookies visible to the current page.

--- a/lib/commands/find.ts
+++ b/lib/commands/find.ts
@@ -1,5 +1,5 @@
-import {util} from 'appium/support';
-import type {SafariDriver} from '../driver';
+import {util} from 'appium/support.js';
+import type {SafariDriver} from '../driver.js';
 
 /**
  * Find element(s) using the specified strategy and selector.

--- a/lib/commands/record-screen.ts
+++ b/lib/commands/record-screen.ts
@@ -1,9 +1,9 @@
-import {util, fs, net, tempDir} from 'appium/support';
+import {util, fs, net, tempDir} from 'appium/support.js';
 import {waitForCondition} from 'asyncbox';
 import {Simctl} from 'node-simctl';
 import type {SubProcess} from 'teen_process';
 import type {AppiumLogger, StringRecord} from '@appium/types';
-import type {SafariDriver} from '../driver';
+import type {SafariDriver} from '../driver.js';
 
 const STARTUP_INTERVAL_MS = 300;
 const STARTUP_TIMEOUT_MS = 10 * 1000;

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -7,14 +7,14 @@ import type {
   ExternalDriver,
   W3CDriverCaps,
 } from '@appium/types';
-import {BaseDriver} from 'appium/driver';
-import {SafariDriverServer} from './safari';
-import {desiredCapConstraints, type SafariConstraints} from './desired-caps';
-import * as cookieCommands from './commands/cookies';
-import * as findCommands from './commands/find';
-import * as recordScreenCommands from './commands/record-screen';
-import {formatCapsForServer} from './utils';
-import {newMethodMap} from './method-map';
+import {BaseDriver} from 'appium/driver.js';
+import {SafariDriverServer} from './safari.js';
+import {desiredCapConstraints, type SafariConstraints} from './desired-caps.js';
+import * as cookieCommands from './commands/cookies.js';
+import * as findCommands from './commands/find.js';
+import * as recordScreenCommands from './commands/record-screen.js';
+import {formatCapsForServer} from './utils.js';
+import {newMethodMap} from './method-map.js';
 
 const NO_PROXY: RouteMatcher[] = [
   ['GET', new RegExp('^/session/[^/]+/appium')],

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-import {SafariDriver} from './driver';
+import {SafariDriver} from './driver.js';
 
 export default SafariDriver;
 export {SafariDriver};

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,4 +1,4 @@
-import {logger} from 'appium/support';
+import {logger} from 'appium/support.js';
 
 const log = logger.getLogger('Safari');
 

--- a/lib/method-map.ts
+++ b/lib/method-map.ts
@@ -1,4 +1,4 @@
-import type {SafariDriver} from './driver';
+import type {SafariDriver} from './driver.js';
 import type {MethodMap} from '@appium/types';
 
 export const newMethodMap = {

--- a/lib/safari.ts
+++ b/lib/safari.ts
@@ -1,7 +1,7 @@
 import os from 'node:os';
 import path from 'node:path';
-import {JWProxy, errors} from 'appium/driver';
-import {fs, logger, util} from 'appium/support';
+import {JWProxy, errors} from 'appium/driver.js';
+import {fs, logger, util} from 'appium/support.js';
 import {SubProcess} from 'teen_process';
 import {waitForCondition} from 'asyncbox';
 import {findAPortNotInUse} from 'portscanner';

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,4 @@
-import {STANDARD_CAPS} from 'appium/driver';
+import {STANDARD_CAPS} from 'appium/driver.js';
 import type {StringRecord} from '@appium/types';
 
 const SAFARI_CAP_PREFIXES = ['safari:', 'webkit:'];

--- a/package.json
+++ b/package.json
@@ -33,8 +33,15 @@
     ],
     "mainClass": "SafariDriver"
   },
+  "type": "module",
   "main": "./build/lib/index.js",
   "types": "./build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js"
+    }
+  },
   "bin": {},
   "directories": {
     "lib": "lib"
@@ -62,8 +69,9 @@
     "format": "prettier -w ./lib ./test",
     "format:check": "prettier --check ./lib ./test",
     "prepare": "npm run build",
-    "test": "mocha --exit --timeout 1m \"./test/unit/**/*-specs.ts\"",
-    "e2e-test": "mocha --exit --timeout 5m \"./test/functional/**/*-specs.ts\""
+    "pretest": "npm run build",
+    "test": "node --test --test-timeout=60000 \"build/test/unit/**/*.test.js\"",
+    "e2e-test": "npm run build && node --test --test-timeout=300000 \"build/test/functional/**/*.test.js\""
   },
   "peerDependencies": {
     "appium": "^3.0.0-rc.2"
@@ -74,18 +82,11 @@
     "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
-    "@types/chai": "^5.2.3",
-    "@types/chai-as-promised": "^8.0.2",
-    "@types/mocha": "^10.0.1",
     "@types/node": "^25.0.0",
     "@types/portscanner": "^2.1.4",
-    "chai": "^6.0.0",
-    "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^9.0.0",
-    "mocha": "^11.1.0",
     "prettier": "^3.0.3",
     "semantic-release": "^25.0.2",
-    "ts-node": "^10.9.1",
     "typescript": "^6.0.2",
     "webdriverio": "^9.0.5"
   }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,9 @@
     "prepare": "npm run build",
     "pretest": "npm run build",
     "test": "node --test --test-timeout=60000 \"build/test/unit/**/*.test.js\"",
-    "e2e-test": "npm run build && node --test --test-timeout=300000 \"build/test/functional/**/*.test.js\""
+    "e2e-test": "npm run build && node --test --test-timeout=300000 \"build/test/functional/**/*.test.js\"",
+    "e2e-test:desktop": "npm run build && node --test --test-timeout=300000 build/test/functional/desktop-driver-e2e.test.js",
+    "e2e-test:simulator": "npm run build && node --test --test-timeout=300000 build/test/functional/mobile-driver-e2e.test.js"
   },
   "peerDependencies": {
     "appium": "^3.0.0-rc.2"

--- a/test/functional/desktop-driver-e2e.test.ts
+++ b/test/functional/desktop-driver-e2e.test.ts
@@ -1,11 +1,8 @@
+import {describe, it, beforeEach, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
 import {remote} from 'webdriverio';
-import {HOST, PORT, MOCHA_TIMEOUT} from '../utils';
+import {HOST, PORT, TEST_TIMEOUT} from '../utils.js';
 import type {Browser} from 'webdriverio';
-import {expect} from 'chai';
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-
-chai.use(chaiAsPromised.default);
 
 const CAPS = {
   browserName: 'AppiumSafari',
@@ -14,27 +11,25 @@ const CAPS = {
   'wdio:enforceWebDriverClassic': true,
 };
 
-describe('Desktop SafariDriver', function () {
-  this.timeout(MOCHA_TIMEOUT);
-
+describe('Desktop SafariDriver', {timeout: TEST_TIMEOUT}, () => {
   let driver: Browser | null = null;
 
-  beforeEach(async function () {
+  beforeEach(async () => {
     driver = await remote({
       hostname: HOST,
       port: PORT,
       capabilities: CAPS,
     });
   });
-  afterEach(async function () {
+  afterEach(async () => {
     if (driver) {
       await driver.deleteSession();
       driver = null;
     }
   });
 
-  it('should start and stop a session', async function () {
+  it('should start and stop a session', async () => {
     await driver!.url('https://appium.io/');
-    expect(await driver!.getPageSource()).to.not.be.empty;
+    assert.ok(await driver!.getPageSource());
   });
 });

--- a/test/functional/mobile-driver-e2e.test.ts
+++ b/test/functional/mobile-driver-e2e.test.ts
@@ -1,12 +1,9 @@
+import {describe, it, before, beforeEach, afterEach} from 'node:test';
+import assert from 'node:assert/strict';
 import {remote} from 'webdriverio';
 import {Simctl} from 'node-simctl';
-import {HOST, PORT, MOCHA_TIMEOUT} from '../utils';
+import {HOST, PORT, TEST_TIMEOUT} from '../utils.js';
 import type {Browser} from 'webdriverio';
-import {expect} from 'chai';
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-
-chai.use(chaiAsPromised.default);
 
 const PLATFORM_VERSION = process.env.PLATFORM_VERSION || '14.1';
 const DEVICE_NAME = process.env.DEVICE_NAME || 'iPhone 11 Pro Max';
@@ -20,19 +17,12 @@ const CAPS = {
   'wdio:enforceWebDriverClassic': true,
 };
 
-describe('Mobile SafariDriver', function () {
-  this.timeout(MOCHA_TIMEOUT);
+const describeMobile = process.env.CI ? describe.skip : describe;
 
+describeMobile('Mobile SafariDriver', {timeout: TEST_TIMEOUT}, () => {
   let driver: Browser | null = null;
 
-  before(async function () {
-    if (process.env.CI) {
-      // In Azure CI the stuff unexpectedly fails with
-      // "The device is not configured to allow remote control via WebDriver. To fix this, toggle 'Allow Remote Automation' in Safari's settings (Settings App > Safari > Advanced)."
-      // error
-      return this.skip();
-    }
-
+  before(async () => {
     // Preboot Simulator to avoid unexpected timeouts
     const simctl = new Simctl();
     const allDevices = await simctl.getDevices(PLATFORM_VERSION, 'iOS');
@@ -46,22 +36,22 @@ describe('Mobile SafariDriver', function () {
       await simctl.startBootMonitor();
     }
   });
-  beforeEach(async function () {
+  beforeEach(async () => {
     driver = await remote({
       hostname: HOST,
       port: PORT,
       capabilities: CAPS,
     });
   });
-  afterEach(async function () {
+  afterEach(async () => {
     if (driver) {
       await driver.deleteSession();
       driver = null;
     }
   });
 
-  it('should start and stop a session', async function () {
+  it('should start and stop a session', async () => {
     await driver!.url('https://appium.io/');
-    expect(await driver!.getPageSource()).to.not.be.empty;
+    assert.ok(await driver!.getPageSource());
   });
 });

--- a/test/functional/mobile-driver-e2e.test.ts
+++ b/test/functional/mobile-driver-e2e.test.ts
@@ -1,46 +1,39 @@
 import {describe, it, before, beforeEach, afterEach} from 'node:test';
 import assert from 'node:assert/strict';
 import {remote} from 'webdriverio';
-import {Simctl} from 'node-simctl';
-import {HOST, PORT, TEST_TIMEOUT} from '../utils.js';
+import {HOST, PORT, TEST_TIMEOUT, resolveSimulatorTarget, type SimulatorTarget} from '../utils.js';
 import type {Browser} from 'webdriverio';
 
-const PLATFORM_VERSION = process.env.PLATFORM_VERSION || '14.1';
-const DEVICE_NAME = process.env.DEVICE_NAME || 'iPhone 11 Pro Max';
-const CAPS = {
-  browserName: 'AppiumSafari',
-  platformName: 'ios',
-  'appium:automationName': 'safari',
-  'safari:useSimulator': true,
-  'safari:platformVersion': PLATFORM_VERSION,
-  'safari:deviceName': DEVICE_NAME,
-  'wdio:enforceWebDriverClassic': true,
-};
-
-const describeMobile = process.env.CI ? describe.skip : describe;
-
-describeMobile('Mobile SafariDriver', {timeout: TEST_TIMEOUT}, () => {
+describe('Mobile SafariDriver', {timeout: TEST_TIMEOUT}, () => {
   let driver: Browser | null = null;
+  let simulator: SimulatorTarget;
+  let caps: Record<string, string | boolean>;
 
   before(async () => {
+    simulator = await resolveSimulatorTarget();
+
+    caps = {
+      browserName: 'AppiumSafari',
+      platformName: 'iOS',
+      'appium:automationName': 'safari',
+      'safari:useSimulator': true,
+      'safari:platformVersion': simulator.platformVersion,
+      'safari:deviceName': simulator.deviceName,
+      'safari:deviceUDID': simulator.udid,
+      'wdio:enforceWebDriverClassic': true,
+    };
+
     // Preboot Simulator to avoid unexpected timeouts
-    const simctl = new Simctl();
-    const allDevices = await simctl.getDevices(PLATFORM_VERSION, 'iOS');
-    const device = allDevices.find(({name}) => name === DEVICE_NAME);
-    if (!device) {
-      throw new Error(`Cannot find '${DEVICE_NAME}' Simulator (${PLATFORM_VERSION})`);
-    }
-    if (device.state !== 'Booted') {
-      simctl.udid = device.udid;
-      await simctl.bootDevice();
-      await simctl.startBootMonitor();
+    if (simulator.state !== 'Booted') {
+      await simulator.simctl.bootDevice();
+      await simulator.simctl.startBootMonitor();
     }
   });
   beforeEach(async () => {
     driver = await remote({
       hostname: HOST,
       port: PORT,
-      capabilities: CAPS,
+      capabilities: caps,
     });
   });
   afterEach(async () => {

--- a/test/unit/driver-specs.ts
+++ b/test/unit/driver-specs.ts
@@ -1,8 +1,0 @@
-import {SafariDriver} from '../../lib/driver';
-import {expect} from 'chai';
-
-describe('SafariDriver', function () {
-  it('should exist', function () {
-    expect(SafariDriver).to.exist;
-  });
-});

--- a/test/unit/driver.test.ts
+++ b/test/unit/driver.test.ts
@@ -1,0 +1,9 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import {SafariDriver} from '../../lib/driver.js';
+
+describe('SafariDriver', () => {
+  it('should exist', () => {
+    assert.ok(SafariDriver);
+  });
+});

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,37 +1,38 @@
-import {formatCapsForServer} from '../../lib/utils';
-import {expect} from 'chai';
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import {formatCapsForServer} from '../../lib/utils.js';
 
-describe('formatCapsForServer', function () {
-  it('should format empty caps', function () {
+describe('formatCapsForServer', () => {
+  it('should format empty caps', () => {
     const result = formatCapsForServer({});
-    expect(result).to.eql({
+    assert.deepEqual(result, {
       browserName: 'Safari',
       browserVersion: undefined,
       platformName: 'iOS',
     });
   });
 
-  it('should assign default caps', function () {
+  it('should assign default caps', () => {
     const result = formatCapsForServer({
       browserName: 'yolo',
       browserVersion: '12',
       platformName: 'mac',
     });
-    expect(result).to.eql({
+    assert.deepEqual(result, {
       browserName: 'Safari',
       browserVersion: '12',
       platformName: 'mac',
     });
   });
 
-  it('should only pass caps with supported prefixes and standard caps', function () {
+  it('should only pass caps with supported prefixes and standard caps', () => {
     const result = formatCapsForServer({
       'safari:deviceUDID': '1234',
       'webkit:yolo': '567',
       'appium:bar': '789',
       acceptInsecureCerts: true,
     });
-    expect(result).to.eql({
+    assert.deepEqual(result, {
       browserName: 'Safari',
       browserVersion: undefined,
       platformName: 'iOS',

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,3 +1,3 @@
 export const HOST = process.env.APPIUM_TEST_SERVER_HOST || '127.0.0.1';
 export const PORT = parseInt(process.env.APPIUM_TEST_SERVER_PORT || '4567', 10);
-export const MOCHA_TIMEOUT = 240000;
+export const TEST_TIMEOUT = 240000;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,3 +1,44 @@
+import {Simctl} from 'node-simctl';
+
 export const HOST = process.env.APPIUM_TEST_SERVER_HOST || '127.0.0.1';
 export const PORT = parseInt(process.env.APPIUM_TEST_SERVER_PORT || '4567', 10);
 export const TEST_TIMEOUT = 240000;
+
+export interface SimulatorTarget {
+  simctl: Simctl;
+  platformVersion: string;
+  deviceName: string;
+  udid: string;
+  state: string;
+}
+
+/**
+ * Resolves the iOS Simulator to use for mobile Safari e2e tests from environment variables.
+ * Requires PLATFORM_VERSION and DEVICE_NAME. DEVICE_UDID is optional.
+ */
+export async function resolveSimulatorTarget(): Promise<SimulatorTarget> {
+  const platformVersion = process.env.PLATFORM_VERSION;
+  const deviceName = process.env.DEVICE_NAME;
+  if (!platformVersion || !deviceName) {
+    throw new Error('PLATFORM_VERSION and DEVICE_NAME environment variables must be set');
+  }
+
+  const simctl = new Simctl();
+  const allDevices = await simctl.getDevices(platformVersion, 'iOS');
+  const envUdid = process.env.DEVICE_UDID;
+  const device = envUdid
+    ? allDevices.find(({udid}) => udid.toLowerCase() === envUdid.toLowerCase())
+    : allDevices.find(({name}) => name === deviceName);
+  if (!device) {
+    throw new Error(`Cannot find '${deviceName}' simulator for iOS ${platformVersion}`);
+  }
+
+  simctl.udid = device.udid;
+  return {
+    simctl,
+    platformVersion,
+    deviceName: device.name,
+    udid: device.udid,
+    state: device.state,
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,15 +3,12 @@
   "extends": "@appium/tsconfig/tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "types": ["node", "mocha"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": ".",
+    "types": ["node"],
     "checkJs": true,
     "strict": true
-  },
-  "ts-node": {
-    "transpileOnly": true,
-    "compilerOptions": {
-      "rootDir": "."
-    }
   },
   "include": [
     "lib",


### PR DESCRIPTION
## Summary

BREAKING CHANGE: Migrate the package to native ESM (`"type": "module"`, `exports` map, `NodeNext` TypeScript output, `.js` import extensions, `appium/driver.js` / `appium/support.js` subpath imports). Consumers using `require()` against deep/internal paths will need to switch to ESM `import` or use the published `exports` entry point.

Follows the same approach as [appium/appium-geckodriver#165](https://github.com/appium/appium-geckodriver/pull/165).

## ESM migration

- Add `"type": "module"` and an `exports` map pointing at `build/lib/index.js`
- Configure TypeScript for `NodeNext` module resolution and remove `ts-node` config
- Add `.js` extensions to all relative imports across `lib/`
- Update Appium subpath imports to `appium/driver.js` and `appium/support.js`

## Testing

- Remove Mocha, Chai, `chai-as-promised`, `ts-node`, and related `@types/*` packages
- Migrate unit and e2e tests to Node's built-in test runner (`node:test` + `node:assert/strict`)
- Rename test files from `*-specs.ts` to `*.test.ts`
- Remove `.mocharc.js`
- Unit tests: `node --test build/test/unit/**/*.test.js`
- E2E tests: `node --test build/test/functional/**/*.test.js`
- Mobile e2e suite is skipped in CI via `describe.skip` (unchanged behavior)
