### PR TITLE
chore: downgrade conventional-changelog-conventionalcommits to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@semantic-release/git": "^10.0.1",
     "@types/node": "^26.0.0",
     "@types/portscanner": "^2.1.4",
-    "conventional-changelog-conventionalcommits": "^10.2.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "prettier": "^3.0.3",
     "semantic-release": "^25.0.2",
     "typescript": "^6.0.2",


### PR DESCRIPTION
`@semantic-release` does not yet fully support `conventional-changelog-conventionalcommits` v10: https://github.com/semantic-release/release-notes-generator/issues/992