### PR TITLE
docs: tune capabilities & other pages

### DIFF
--- a/docs/guides/non-macos.md
+++ b/docs/guides/non-macos.md
@@ -32,7 +32,7 @@ A simple capability set for a new iOS/iPadOS session can then look as follows:
 }
 ```
 
-It is recommended to use [Safari-specific capabilities](../reference/capabilities.md#safari-specific) such as
+It is recommended to use [Safari-specific capabilities](../reference/capabilities.md#safari) such as
 `safari:useSimulator`, `safari:deviceName`, `safari:deviceUDID` and others to specify the exact
 test device:
 

--- a/docs/reference/bidi.md
+++ b/docs/reference/bidi.md
@@ -2,13 +2,13 @@
 hide:
   - toc
 
-title: BiDi Events
+title: BiDi Commands and Events
 ---
 
 The Safari driver **does not** support the [WebDriver BiDi Protocol](https://w3c.github.io/webdriver-bidi/):
 
-* The driver inherits [all BiDi endpoints supported by the Appium base driver](https://appium.io/docs/en/latest/reference/api/bidi/)
-* The driver does not define any additional endpoints
+* The driver inherits [all BiDi commands and events supported by the Appium base driver](https://appium.io/docs/en/latest/reference/api/bidi/)
+* The driver does not define any additional commands or events
 * The underlying `safaridriver` binary does not support the WebDriver BiDi protocol at all [^wpt]
 
 [^wpt]: Refer to the [Web Platform Tests WebDriver BiDi test results](https://wpt.fyi/results/webdriver/tests/bidi)

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -10,41 +10,169 @@ For other capabilities recognized by the Appium server, see
 
 ## Standard
 
-| <div style="width:11em">Capability</div> | Description |
-| --- | --- |
-| `platformName` | Must be set to `mac` or `ios` (case-insensitive) |
-| `browserName` |	Any value passed to this capability will be changed to `safari` |
-| `browserVersion` | Only allow sessions on devices that have this version of Safari. Numbers are prefix-matched - for example, a value of '12' will allow hosts with a Safari version of '12.0.1' or '12.1'. |
-| `acceptInsecureCerts` | [Refer to the W3C Webdriver documentation](https://www.w3.org/TR/webdriver/#capabilities). Requires Safari 15.4 or later. [^acceptinsecurecerts] |
+Refer to [the W3C WebDriver documentation](https://w3c.github.io/webdriver/#capabilities)
+for more information about these capabilities.
 
-## Appium-Specific
+### platformName
 
-| Capability | Description |
-| --- | --- |
-| `appium:automationName` | Must be set to `Safari` (case-insensitive) |
+| Name | Type | Default |
+| -- | -- | -- |
+| `platformName` | `string` | Not specified |
 
-## Safari-Specific
+This capability must be set to `mac` or `ios` (case-insensitive)
 
-| <div style="width:15em">Capability</div> | Description |
-| --- | --- |
-| `safari:platformVersion` | Only allow sessions on devices that have this OS version. Numbers are prefix-matched - for example, a value of '12' will allow hosts with an OS version of '12.0.1' or '12.1'. |
-| `safari:platformBuildVersion` | Only allow sessions on devices that have this OS build version, for example '18E193'. On macOS, the OS build version can be determined by running the `sw_vers(1)` utility. |
-| `safari:useSimulator` | Whether to run tests on an iOS/iPadOS simulator device. Note that simulators require Xcode to be installed. Set to `false` by default. |
-| `safari:deviceType` | Only allow sessions on devices that match this device type. Supported values are `iPhone` and `iPad` (case-insensitive). |
-| `safari:deviceName` | Only allow sessions on devices with this device name (case-insensitive). |
-| `safari:deviceUDID` | Only allow sessions on devices with this device UDID (case-insensitive). |
-| `safari:automaticInspection` | Whether to preload the Web Inspector and JavaScript debugger in the background. If set to `true`, when evaluating a `debugger;` statement in the test page, test execution will be paused, and the Web Inspector's Debugger tab will open. |
-| `safari:automaticProfiling` | Whether to preload the Web Inspector and start a timeline recording in the background. If set to `true`, the Timelines tab in Web Inspector will show the captured timeline recording in its entirety. |
-| `safari:diagnose` | Whether to enable `safaridriver` diagnostics for this session. Diagnostic files are saved to `~/Library/Logs/com.apple.WebDriver`. The Safari driver enables diagnostics for all sessions, so this capability has no effect. |
+### browserName
 
-## WebKit-Specific
+| Name | Type | Default |
+| -- | -- | -- |
+| `browserName` | `string` | `Safari` |
 
-| <div style="width:15em">Capability</div> | Description |
-| --- | --- |
-| `webkit:WebRTC` | Change Safari's policies for WebRTC and Media Capture. This capability is a dictionary with following optional sub-keys: `DisableInsecureMediaCapture` (whether to prevent media capture over insecure connections, which is allowed by default in WebDriver sessions), and  `DisableICECandidateFiltering` (whether to skip filtering of WebRTC ICE candidates, which by default filters out candidates that correspond to internal network addresses). |
-| `webkit:alwaysAllowAutoplay` | Whether to always allow autoplay of all media elements without user interaction, overriding any per-website settings. Requires Safari 18.6 or later. [^alwaysallowautoplay] |
-| `webkit:siteIsolationEnabled` | Whether to enable site isolation. Requires Safari 26.0 or later. [^siteisolationenabled]|
+This capability is always automatically set to `Safari`, so it has no effect.
 
-[^acceptinsecurecerts]: Added in [Safari Technology Preview 135](https://webkit.org/blog/12040/release-notes-for-safari-technology-preview-135/), whose features were [included in Safari 15.4](https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/#and-more)
-[^alwaysallowautoplay]: Added in [Safari Technology Preview 222](https://webkit.org/blog/17216/release-notes-for-safari-technology-preview-222/), whose features were included in Safari 18.6
-[^siteisolationenabled]: Added in [Safari Technology Preview 225](https://webkit.org/blog/17216/release-notes-for-safari-technology-preview-225/), whose features were included in Safari 26.0
+### browserVersion
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `browserVersion` | `string` | Not specified |
+
+Only allow sessions on devices that have this version of Safari. Numbers are prefix-matched - for
+example, a value of '12' will allow hosts with a Safari version of '12.0.1' or '12.1'.
+
+### acceptInsecureCerts
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `acceptInsecureCerts` | `boolean` | `false` |
+
+This capability requires Safari 15.4 or later (originally added in [Safari Technology Preview 135](https://webkit.org/blog/12040/release-notes-for-safari-technology-preview-135/)).
+
+## General
+
+### automationName
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `appium:automationName` | `string` | Not specified |
+
+Specifies the Appium driver to use. Must be set to `Safari` (case-insensitive)
+
+## Safari
+
+### platformVersion
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `safari:platformVersion` | `string` | Not specified |
+
+Only allow sessions on devices that have this OS version. Numbers are prefix-matched - for example,
+a value of '12' will allow hosts with an OS version of '12.0.1' or '12.1'.
+
+### platformBuildVersion
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `safari:platformBuildVersion` | `string` | Not specified |
+
+Only allow sessions on devices that have this OS build version, for example '18E193'. On macOS, the
+OS build version can be determined by running the `sw_vers(1)` utility.
+
+### useSimulator
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `safari:useSimulator` | `boolean` | `false` |
+
+Whether to run tests on an iOS/iPadOS simulator device. Note that simulators require Xcode to be
+installed.
+
+### deviceType
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `safari:deviceType` | `string` | Not specified |
+
+Only allow sessions on devices that match this device type. Supported values are `iPhone` and
+`iPad` (case-insensitive).
+
+### deviceName
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `safari:deviceName` | `string` | Not specified |
+
+Only allow sessions on devices with this device name (case-insensitive)
+
+### deviceUDID
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `safari:deviceUDID` | `string` | Not specified |
+
+Only allow sessions on devices with this device UDID (case-insensitive)
+
+### automaticInspection
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `safari:automaticInspection` | `boolean` | `false` |
+
+Whether to preload the Web Inspector and JavaScript debugger in the background. If set to `true`,
+when evaluating a `debugger;` statement in the test page, test execution will be paused, and the
+Web Inspector's Debugger tab will open.
+
+### automaticProfiling
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `safari:automaticProfiling` | `boolean` | `false` |
+
+Whether to preload the Web Inspector and start a timeline recording in the background. If set to
+`true`, the Timelines tab in Web Inspector will show the captured timeline recording in its entirety.
+
+### diagnose
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `safari:diagnose` | `boolean` | `true` |
+
+Whether to enable `safaridriver` diagnostics for this session. Diagnostic files are saved to
+`~/Library/Logs/com.apple.WebDriver`.
+
+The Safari driver enables diagnostics for all sessions, so this capability has no effect.
+
+## WebKit
+
+### webRTC
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `webkit:WebRTC` | `Record<string, boolean>` | Not specified |
+
+Change Safari's policies for WebRTC and Media Capture. This capability is a dictionary with the
+following optional sub-keys:
+
+* `DisableInsecureMediaCapture` - whether to prevent media capture over insecure connections, which
+  is allowed by default in WebDriver sessions
+* `DisableICECandidateFiltering` - whether to skip filtering of WebRTC ICE candidates, which by
+  default filters out candidates that correspond to internal network addresses
+
+### alwaysAllowAutoplay
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `webkit:alwaysAllowAutoplay` | `boolean` | `false` |
+
+Whether to always allow autoplay of all media elements without user interaction, overriding any
+per-website settings.
+
+This capability requires Safari 18.6 or later (originally added in [Safari Technology Preview 222](https://webkit.org/blog/17216/release-notes-for-safari-technology-preview-222/)).
+
+### siteIsolationEnabled
+
+| Name | Type | Default |
+| -- | -- | -- |
+| `webkit:siteIsolationEnabled` | `boolean` | `false` |
+
+Whether to enable site isolation.
+
+This capability requires Safari 26.0 or later (originally added in [Safari Technology Preview 225](https://webkit.org/blog/17216/release-notes-for-safari-technology-preview-225/)).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,8 +34,8 @@ nav:
   - Reference:
       - Session Configuration:
           - reference/capabilities.md
-          - reference/bidi.md
           - reference/endpoints.md
+          - reference/bidi.md
       - Element Management:
           - reference/locator-strategies.md
   - Guides:


### PR DESCRIPTION
This adjusts some documentation pages to match the formatting of the Mac2 driver documentation:
* Expanded format of the capabilities page
* Rename 'BiDi Events' to 'BiDi Commands and Events' and align page placement in navigation sidebar